### PR TITLE
Merge changes for v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The following items can be toggled in the configuration menu.
 * 1 cooked salmon or gnomeball
 * 4 pie dishes or ground bat bones
 * 9 brass keys or amulets of magic
-* 10 Al kharid flyers or rocks (elemental)
+* 10 Oak roots, Al kharid flyers, or rocks (elemental)
 ## Instructions
 1. Deposit all items, including equipped items. Coins can be left in your inventory.
 2. Withdraw the item you want to weigh.

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 group = 'com.weight-calc'
-version = '1.1'
+version = '1.2'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/weightcalc/WeightCalcConfig.java
+++ b/src/main/java/com/weightcalc/WeightCalcConfig.java
@@ -33,6 +33,6 @@ public interface WeightCalcConfig extends Config
 	@ConfigItem(keyName = THOUSANDTH_KG_KEYNAME, name = "0.001 kg", description = "Weighing item to use for 0.001 kg")
 	default WeightCalcEnum.ThousandthKg thousandthKgConfig()
 	{
-		return WeightCalcEnum.ThousandthKg.AL_KHARID_FLYER;
+		return WeightCalcEnum.ThousandthKg.OAK_ROOTS;
 	}
 }

--- a/src/main/java/com/weightcalc/WeightCalcConfig.java
+++ b/src/main/java/com/weightcalc/WeightCalcConfig.java
@@ -11,6 +11,7 @@ public interface WeightCalcConfig extends Config
 	String TENTH_KG_KEYNAME = "0.100";
 	String HUNDREDTH_KG_KEYNAME = "0.010";
 	String THOUSANDTH_KG_KEYNAME = "0.001";
+	String SHOW_WEIGHTS_TOGGLE_KEYNAME = "showWeightsToggle";
 
 	@ConfigItem(keyName = HALF_KG_KEYNAME, name = "0.500 kg", description = "Weighing item to use for 0.500 kg")
 	default WeightCalcEnum.HalfKg halfKgConfig()
@@ -35,4 +36,7 @@ public interface WeightCalcConfig extends Config
 	{
 		return WeightCalcEnum.ThousandthKg.OAK_ROOTS;
 	}
+
+	@ConfigItem(keyName = SHOW_WEIGHTS_TOGGLE_KEYNAME, name = "Visible weight range", description = "Display the possible range of weights as items are weighed")
+	default boolean showWeightsRange() { return false; }
 }

--- a/src/main/java/com/weightcalc/WeightCalcEnum.java
+++ b/src/main/java/com/weightcalc/WeightCalcEnum.java
@@ -2,6 +2,7 @@ package com.weightcalc;
 
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.Item;
 import net.runelite.api.ItemID;
 
 public class WeightCalcEnum
@@ -61,7 +62,8 @@ public class WeightCalcEnum
 	public enum ThousandthKg implements WeighingItem
 	{
 		ROCK(ItemID.ROCK_1480),
-		AL_KHARID_FLYER(ItemID.AL_KHARID_FLYER);
+		AL_KHARID_FLYER(ItemID.AL_KHARID_FLYER),
+		OAK_ROOTS(ItemID.OAK_ROOTS);
 
 		@Getter
 		@Setter

--- a/src/main/java/com/weightcalc/WeightCalcOverlayPanel.java
+++ b/src/main/java/com/weightcalc/WeightCalcOverlayPanel.java
@@ -73,10 +73,10 @@ public class WeightCalcOverlayPanel extends OverlayPanel
 				panelComponent.getChildren().add(LineComponent.builder().left("Final weight: " + (BigDecimal.ONE.subtract(maxWeight).add(aloneWeight).toString())).build());
 			}
 			// Might want to add this as a toggle for debugging.
-			// else
-			// {
-			// 	panelComponent.getChildren().add(LineComponent.builder().left("Added weights to try: " + minWeight.toString() + " - " + maxWeight.toString()).build());
-			// }
+			else if (config.showWeightsRange())
+			{
+				panelComponent.getChildren().add(LineComponent.builder().left("Possible weights: " + (BigDecimal.ONE.subtract(maxWeight).add(aloneWeight)) + " - " + (BigDecimal.ONE.subtract(minWeight).add(aloneWeight))).build());
+			}
 		}
 
 

--- a/src/main/java/com/weightcalc/WeightCalcPlugin.java
+++ b/src/main/java/com/weightcalc/WeightCalcPlugin.java
@@ -142,7 +142,7 @@ public class WeightCalcPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (InventoryID.INVENTORY.getId() != event.getContainerId())
+		if (InventoryID.INVENTORY.getId() != event.getContainerId() && InventoryID.EQUIPMENT.getId() != event.getContainerId())
 		{
 			return;
 		}


### PR DESCRIPTION
- Allow oak roots to be used for 0.001 kg weights
- Fix bug that stops OverlayPanel from updating when using "Deposit worn items" bank button (fixes #5) 
- Adds a toggle to show the possible weights while weighing items